### PR TITLE
Update cmark to 0.28.3.gfm.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-cmark
 
-node-cmark is a Node.js wrapper around GitHub's fork of [cmark](https://github.com/github/cmark), the reference implementation of [CommonMark](http://commonmark.org/) in C by John MacFarlane. You can find GitHub's fork at https://github.com/github/cmark.
+node-cmark is a Node.js wrapper around GitHub's fork of [cmark](https://github.com/github/cmark-gfm), the reference implementation of [CommonMark](http://commonmark.org/) in C by John MacFarlane. You can find GitHub's fork at https://github.com/github/cmark-gfm.
 
 ## Installation
 
@@ -27,17 +27,22 @@ npm install @binarymuse/cmark
 You can control the behavior of node-cmark by passing options to the rendering functions. The available options are:
 
   * `sourepos` - if `true`, adds a `data-sourcepos` attribute to all block elements that TODO??
-  * `safe` - if `true`, suppresses raw HTML and unsafe links (`javascript:`, `vbscript:`, `file:`, and `data:` except for `image/png`, `image/gif`, `image/jpeg`, or `image/webp` mime types). Raw HTML is replaced by a placeholder HTML comment. Unsafe links are replaced with empty strings.
-  * `nobreaks` - if `true`, renders softbreak elements as spaces
   * `hardbreaks` - if `true`, renders softbreak elements as hard line breaks
-  * `normalize` - if `true`, adjacent text nodes are consolidated
+  * `nobreaks` - if `true`, renders softbreak elements as spaces
   * `validateUtf8` - if `true`, replaces illegal UTF-8 sequences with `U+FFFD`
   * `smart` - if `true`, replaces straight quotes with curly ones, turns `---` into em dashes, and `--` into en dashes
+  * `githubPreLang` - if `true`, uses GitHub style `<pre lang="x">` tags for code blocks
+  * `liberalHtmltag` - if `true`, allows non-well-formed HTML tags to be parsed as HTML (e.g. `< div>` instead of `<div>`)
+  * `footnotes` - if `true`, enables footnote parsing and rendering
+  * `strikethroughDoubleTilde` - if `true`, the `strikethrough` extension will only render text as strikethrough if it is surrounded by `~~two tildes~~`
+  * `fullInfoString` - if `true`, adds additional code block info as an additional attribute on the resulting HTML element
+  * `unsafe` - if `true`, allows raw HTML and unsafe links (`javascript:`, `vbscript:`, `file:`, and `data:` except for `image/png`, `image/gif`, `image/jpeg`, or `image/webp` mime types). Otherwise, raw HTML is replaced by a placeholder HTML comment, and unsafe links are replaced with empty strings.
   * `extensions` - an array of extensions to enable. Valid extensions are:
     * `"table"` - render tables
     * `"strikethrough"` - strikethrough
     * `"tagfilter"` - whitelist something
     * `"autolink"` - automatically turn URLs into links
+    * `"tasklist"` - renders GitHub style task lists
 
 ### Rendering to HTML
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# node-cmark
+# cmark-gfm
 
-node-cmark is a Node.js wrapper around GitHub's fork of [cmark](https://github.com/github/cmark-gfm), the reference implementation of [CommonMark](http://commonmark.org/) in C by John MacFarlane. You can find GitHub's fork at https://github.com/github/cmark-gfm.
+cmark-gfm is a Node.js wrapper around GitHub's [GFM-enhanced](https://github.github.com/gfm/) fork of [cmark](https://github.com/github/cmark-gfm), the reference implementation of [CommonMark](http://commonmark.org/) in C by John MacFarlane. You can find GitHub's fork at https://github.com/github/cmark-gfm.
 
 ## Installation
 
 ```
-npm install @binarymuse/cmark
+npm install cmark-gfm
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ npm install @binarymuse/cmark
 
 **Options**
 
-You can control the behavior of node-cmark by passing options to the rendering functions. The available options are:
+You can control the behavior of cmark-gfm by passing options to the rendering functions. The available options are:
 
   * `sourepos` - if `true`, adds a `data-sourcepos` attribute to all block elements that TODO??
   * `hardbreaks` - if `true`, renders softbreak elements as hard line breaks
@@ -49,7 +49,7 @@ You can control the behavior of node-cmark by passing options to the rendering f
 You can turn a string containing Markdown into HTML either synchronously:
 
 ```javascript
-const cmark = require('node-cmark')
+const cmark = require('cmark-gfm')
 
 const markdown = '# Hello World'
 const options = {}
@@ -60,7 +60,7 @@ console.log(html)
 or asynchronously
 
 ```javascript
-const cmark = require('node-cmark')
+const cmark = require('cmark-gfm')
 
 const markdown = '# Hello World'
 const options = {}

--- a/binding.gyp
+++ b/binding.gyp
@@ -40,6 +40,7 @@
         'cmark/src/cmark.c',
         'cmark/src/cmark_ctype.c',
         'cmark/src/commonmark.c',
+        'cmark/src/footnotes.c',
         'cmark/src/houdini_href_e.c',
         'cmark/src/houdini_html_e.c',
         'cmark/src/houdini_html_u.c',
@@ -50,7 +51,9 @@
         'cmark/src/linked_list.c',
         'cmark/src/main.c',
         'cmark/src/man.c',
+        'cmark/src/map.c',
         'cmark/src/node.c',
+        'cmark/src/plaintext.c',
         'cmark/src/plugin.c',
         'cmark/src/references.c',
         'cmark/src/registry.c',
@@ -64,7 +67,8 @@
         'cmark/extensions/ext_scanners.c',
         'cmark/extensions/strikethrough.c',
         'cmark/extensions/table.c',
-        'cmark/extensions/tagfilter.c'
+        'cmark/extensions/tagfilter.c',
+        'cmark/extensions/tasklist.c',
       ],
       'xcode_settings': {
         'MACOSX_DEPLOYMENT_TARGET': '10.8',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@binarymuse/cmark",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binarymuse/cmark",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Node bindings to the cmark Markdown parser",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@binarymuse/cmark",
+  "name": "cmark-gfm",
   "version": "0.0.6",
-  "description": "Node bindings to the cmark Markdown parser",
+  "description": "Node bindings to GitHub's GFM-enhanced fork of the cmark Markdown parser",
   "main": "index.js",
   "scripts": {
     "build": "node-gyp rebuild",
@@ -10,7 +10,9 @@
   "keywords": [
     "markdown",
     "cmark",
-    "commonmark"
+    "commonmark",
+    "gfm",
+    "cmark-gfm"
   ],
   "author": "Michelle Tilley <michelle@michelletilley.net>",
   "license": "MIT",

--- a/src/async.cc
+++ b/src/async.cc
@@ -1,6 +1,6 @@
 #include "napi.h"
 
-#include "cmark.h"
+#include "cmark-gfm.h"
 #include "markdown.h"
 #include "async.h"
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,6 +1,6 @@
 #include "napi.h"
 
-#include "cmark.h"
+#include "cmark-gfm.h"
 #include "markdown.h"
 #include "sync.h"
 #include "async.h"

--- a/src/markdown.cc
+++ b/src/markdown.cc
@@ -1,17 +1,17 @@
 #include "napi.h"
 
-#include "cmark.h"
+#include "cmark-gfm.h"
 #include "markdown.h"
 #include "parser.h"
 #include "registry.h"
 #include "syntax_extension.h"
-#include "core-extensions.h"
+#include "cmark-gfm-core-extensions.h"
 
 using std::vector;
 using std::string;
 
 void node_cmark_init() {
-  core_extensions_ensure_registered();
+  cmark_gfm_core_extensions_ensure_registered();
 }
 
 void populate_extension_names(Napi::Object options_obj, vector<string>* extension_names) {
@@ -50,13 +50,20 @@ int get_option(Napi::Object options_obj, const char* option_name, int option_mas
 
 int parse_options(Napi::Object options_obj) {
   int result = CMARK_OPT_DEFAULT;
+  // rendering options
   result |= get_option(options_obj, "sourcepos", CMARK_OPT_SOURCEPOS);
-  result |= get_option(options_obj, "safe", CMARK_OPT_SAFE);
-  result |= get_option(options_obj, "nobreaks", CMARK_OPT_NOBREAKS);
   result |= get_option(options_obj, "hardbreaks", CMARK_OPT_HARDBREAKS);
-  result |= get_option(options_obj, "normalize", CMARK_OPT_NORMALIZE);
+  result |= get_option(options_obj, "nobreaks", CMARK_OPT_NOBREAKS);
+  // parsing options
   result |= get_option(options_obj, "validateUtf8", CMARK_OPT_VALIDATE_UTF8);
   result |= get_option(options_obj, "smart", CMARK_OPT_SMART);
+  result |= get_option(options_obj, "githubPreLang", CMARK_OPT_GITHUB_PRE_LANG);
+  result |= get_option(options_obj, "liberalHtmlTag", CMARK_OPT_LIBERAL_HTML_TAG);
+  result |= get_option(options_obj, "footnotes", CMARK_OPT_FOOTNOTES);
+  result |= get_option(options_obj, "strikethroughDoubleTilde", CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE);
+  result |= get_option(options_obj, "tablePreferStyleAttributes", CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES);
+  result |= get_option(options_obj, "fullInfoString", CMARK_OPT_FULL_INFO_STRING);
+  result |= get_option(options_obj, "unsafe", CMARK_OPT_UNSAFE);
   return result;
 }
 

--- a/src/sync.cc
+++ b/src/sync.cc
@@ -1,6 +1,6 @@
 #include "napi.h"
 
-#include "cmark.h"
+#include "cmark-gfm.h"
 #include "markdown.h"
 #include "sync.h"
 

--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -84,10 +84,8 @@ describe('extensions', () => {
 
       const html = `
       <ul>
-      <li class="task-list-item"><input type="checkbox" disabled="" />
-        Task 1</li>
-      <li class="task-list-item"><input type="checkbox" checked="" disabled="" />
-        Task 2</li>
+        <li class="task-list-item"><input type="checkbox" disabled="" /> Task 1</li>
+        <li class="task-list-item"><input type="checkbox" checked="" disabled="" /> Task 2</li>
       </ul>
       `
 

--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -55,7 +55,7 @@ describe('extensions', () => {
       <div>What a weird &lt;xmp> tag</div>
       `
 
-      const rendered = cmark.renderHtmlSync(markdown, {extensions: ['tagfilter']})
+      const rendered = cmark.renderHtmlSync(markdown, {unsafe: true, extensions: ['tagfilter']})
       assert.htmlEqual(rendered, html)
     })
   })
@@ -71,6 +71,27 @@ describe('extensions', () => {
       `
 
       const rendered = cmark.renderHtmlSync(markdown, {extensions: ['autolink']})
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('tasklist', () => {
+    it('renders GitHub-style task lists', () => {
+      const markdown = dedent`
+      - [ ] Task 1
+      - [x] Task 2
+      `
+
+      const html = `
+      <ul>
+      <li class="task-list-item"><input type="checkbox" disabled="" />
+        Task 1</li>
+      <li class="task-list-item"><input type="checkbox" checked="" disabled="" />
+        Task 2</li>
+      </ul>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {extensions: ['tasklist']})
       assert.htmlEqual(rendered, html)
     })
   })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -28,27 +28,6 @@ describe('options', () => {
     })
   })
 
-  describe('safe', () => {
-    it('strips HTML and unsafe links', () => {
-      const markdown = dedent`
-      ![img](data:image/gif;base64,abccdefgh)
-
-      <div>hello!</div>
-
-      [link](javascript:alert('omg'))
-      `.trim()
-
-      const html = `
-      <p><img alt="img" src="data:image/gif;base64,abccdefgh"></p>
-      <!-- raw HTML omitted -->
-      <p><a href="">link</a></p>
-      `
-
-      const rendered = cmark.renderHtmlSync(markdown, {safe: true})
-      assert.htmlEqual(rendered, html)
-    })
-  })
-
   describe('nobreaks', () => {
     it('renders softbreak elements as spaces', () => {
       const markdown = dedent`
@@ -81,12 +60,6 @@ describe('options', () => {
     })
   })
 
-  describe('normalize', () => {
-    xit('consolidates adjacent text nodes', () => {
-      // TODO: how to test? does this even matter in HTML? Text nodes have no wrapper.
-    })
-  })
-
   describe('validateUtf8', () => {
     xit('replaces illegal UTF-8 sequences', () => {
       // TODO: doesn't fail when option is false
@@ -102,7 +75,6 @@ describe('options', () => {
 
   describe('smart', () => {
     it('makes punctuation fancy', () => {
-      // TODO: doesn't fail when option is false
       const markdown = dedent`
       "Good morning," said the man. "Wait -- maybe it's 'afternoon'." --- Someone Famous
       `.trim()
@@ -112,6 +84,242 @@ describe('options', () => {
       `.trim()
 
       const rendered = cmark.renderHtmlSync(markdown, {smart: true})
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('githubPreLang', () => {
+    it('it adds a language class to the code tag by default', () => {
+      const markdown = dedent`
+      \`\`\`javascript
+      console.log('hi')
+      \`\`\`
+      `
+
+      const html = `<pre><code class="language-javascript">console.log('hi')</code></pre>`
+
+      const rendered = cmark.renderHtmlSync(markdown)
+      assert.htmlEqual(rendered, html)
+    })
+
+    it('uses GitHub-style pre tags with lang attributes', () => {
+      const markdown = dedent`
+      \`\`\`javascript
+      console.log('hi')
+      \`\`\`
+      `
+
+      const html = `<pre lang="javascript"><code>console.log('hi')</code></pre>`
+
+      const rendered = cmark.renderHtmlSync(markdown, {githubPreLang: true})
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('liberalHtmlTag', () => {
+    it('requires well-formed tags by default', () => {
+      const markdown = `< div>Hello< /div>`
+
+      const html = `<p>&lt; div&gt;Hello&lt; /div&gt;</p>\n`
+
+      const rendered = cmark.renderHtmlSync(markdown, {unsafe: true})
+      assert.equal(rendered, html)
+    })
+
+    it('allows for spaces inside HTML tag names', () => {
+      const markdown = `< div>Hello< /div>`
+
+      const html = `<p>< div>Hello< /div></p>\n`
+
+      const rendered = cmark.renderHtmlSync(markdown, {unsafe: true, liberalHtmlTag: true})
+      assert.equal(rendered, html)
+    })
+  })
+
+  describe('footnotes', () => {
+    it('parses footnotes', () => {
+      const markdown = dedent`
+      Here is some text[^1].
+
+      [^1]: And the note
+      `
+
+      const html = `
+      <p>Here is some text<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>.</p>
+      <section class="footnotes">
+        <ol>
+          <li id="fn1">
+            <p>And the note <a href="#fnref1" class="footnote-backref">↩</a></p>
+          </li>
+        </ol>
+      </section>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {footnotes: true})
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('strikethroughDoubleTilde', () => {
+    it('parses strikethroughs with any number of tildes by default', () => {
+      const markdown1 = `This is some ~text~!`
+      const markdown2 = `This is some ~~text~~!`
+
+      const rendered1 = cmark.renderHtmlSync(markdown1, {extensions: ['strikethrough']})
+      const rendered2 = cmark.renderHtmlSync(markdown2, {extensions: ['strikethrough']})
+
+      assert.htmlEqual(rendered1, '<p>This is some <del>text</del>!</p>')
+      assert.htmlEqual(rendered2, '<p>This is some <del>text</del>!</p>')
+    })
+
+    it('only parses strikethroughs if surrounded by exactly two tildes', () => {
+      const markdown1 = `This is some ~text~!`
+      const markdown2 = `This is some ~~text~~!`
+
+      const rendered1 = cmark.renderHtmlSync(markdown1, {
+        strikethroughDoubleTilde: true,
+        extensions: ['strikethrough']
+      })
+      const rendered2 = cmark.renderHtmlSync(markdown2, {
+        strikethroughDoubleTilde: true,
+        extensions: ['strikethrough']
+      })
+
+      assert.htmlEqual(rendered1, '<p>This is some ~text~!</p>')
+      assert.htmlEqual(rendered2, '<p>This is some <del>text</del>!</p>')
+    })
+  })
+
+  describe('tablePreferStyleAttributes', () => {
+    it('uses align attributes to align table cells by default', () => {
+      const markdown = dedent`
+      | abc | defghi |
+      :-: | -----------:
+      bar | baz
+      `
+
+      const html = `
+      <table>
+        <thead>
+          <tr>
+            <th align="center">abc</th>
+            <th align="right">defghi</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="center">bar</td>
+            <td align="right">baz</td>
+          </tr>
+        </tbody>
+      </table>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {extensions: ['table']})
+      assert.htmlEqual(rendered, html)
+    })
+
+    it('uses style attributes to align table cells', () => {
+      const markdown = dedent`
+      | abc | defghi |
+      :-: | -----------:
+      bar | baz
+      `
+
+      const html = `
+      <table>
+        <thead>
+          <tr>
+            <th style="text-align: center">abc</th>
+            <th style="text-align: right">defghi</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="text-align: center">bar</td>
+            <td style="text-align: right">baz</td>
+          </tr>
+        </tbody>
+      </table>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {
+        tablePreferStyleAttributes: true,
+        extensions: ['table']
+      })
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('fullInfoString', () => {
+    it('drops the remainder of code block info strings by default', () => {
+      const markdown = dedent`
+      \`\`\`javascript here is more data
+      console.log('hi')
+      \`\`\`
+      `
+
+      const html = `<pre><code class="language-javascript">console.log('hi')</code></pre>`
+
+      const rendered = cmark.renderHtmlSync(markdown)
+      assert.htmlEqual(rendered, html)
+    })
+
+    it('includes the remainder of code block info strings in an attribute', () => {
+      const markdown = dedent`
+      \`\`\`javascript here is more data
+      console.log('hi')
+      \`\`\`
+      `
+
+      const html = `
+      <pre>
+        <code class="language-javascript"
+          data-meta="here is more data">console.log('hi')</code>
+      </pre>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {fullInfoString: true})
+      assert.htmlEqual(rendered, html)
+    })
+  })
+
+  describe('unsafe', () => {
+    it('is safe by default', () => {
+      const markdown = dedent`
+      ![img](data:image/gif;base64,abccdefgh)
+
+      <div>hello!</div>
+
+      [link](javascript:alert('omg'))
+      `.trim()
+
+      const html = `
+      <p><img alt="img" src="data:image/gif;base64,abccdefgh"></p>
+      <!-- raw HTML omitted -->
+      <p><a href="">link</a></p>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown)
+      assert.htmlEqual(rendered, html)
+    })
+
+    it('allows HTML and unsafe links', () => {
+      const markdown = dedent`
+      ![img](data:image/gif;base64,abccdefgh)
+
+      <div>hello!</div>
+
+      [link](javascript:alert('omg'))
+      `.trim()
+
+      const html = `
+      <p><img alt="img" src="data:image/gif;base64,abccdefgh"></p>
+      <div>hello!</div>
+      <p><a href="javascript:alert('omg')">link</a></p>
+      `
+
+      const rendered = cmark.renderHtmlSync(markdown, {unsafe: true})
       assert.htmlEqual(rendered, html)
     })
   })


### PR DESCRIPTION
* Updates vendored cmark to `0.28.3.gfm.20`
* Adds support for new options
  * `githubPreLang`
  * `liberalHtmlTag`
  * `footnotes`
  * `strikethroughDoubleTilde`
  * `fullInfoString`
  * `unsafe`
* Removes support for old options
  * `safe`
  * `normalize`
* Adds support for new extensions
  * `tasklist`

Fixes #2 